### PR TITLE
Add Test::Exception to testing prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -55,6 +55,7 @@ mb_version = 0.2808
 
 [Prereqs / TestRequires]
 Pod::Coverage::TrustPod = 0
+Test::Exception = 0
 
 [Prereqs / Recommends]
 Test::Pod = 1.14


### PR DESCRIPTION
Adding Test::Exception to prereqs -- may clear up a bunch of FAILS on cpantesters
